### PR TITLE
added noopener and noref to a tag to prevent manipulation of window

### DIFF
--- a/templates/help/help.html
+++ b/templates/help/help.html
@@ -22,7 +22,7 @@
                     <strong>Useful Links: </strong>
                 </p>
                 {% for u in data.urls %}
-                <a href="{{ u.url }}" target="_blank" class="card-link">{{ u.title }} <i class="fas fa-link"></i></a>
+                <a href="{{ u.url }}" target="_blank" class="card-link" rel="noopener noreferrer">{{ u.title }} <i class="fas fa-link"></i></a>
                 <br> {% endfor %}
             </div>
         </div>

--- a/templates/levels/levels.html
+++ b/templates/levels/levels.html
@@ -113,7 +113,7 @@
         var urlRegex =/(\b(https?|ftp|file):\/\/[-A-Z0-9+&@#\/%?=~_|!:,.;]*[-A-Z0-9+&@#\/%=~_|])/ig;
 
         return text.replace(urlRegex, function(url) {
-            return '<a href="' + url + '" target="_blank">' + url + ' <i class="fas fa-link"></i></a>';
+            return '<a href="' + url + '" target="_blank" rel="noopener noreferrer">' + url + ' <i class="fas fa-link"></i></a>';
         })
     } 
 </script>


### PR DESCRIPTION
the a tags were missing 'noopener' and 'noreferer'. A page opened with 'target="_blank"' can access the window object of the origin page. This means it can manipulate the 'window.opener' property, which could redirect the origin page to a malicious URL. This is called reverse tabnabbing. 