### PR TITLE
Fixing issue #64

### DIFF
--- a/asvs/settings.py
+++ b/asvs/settings.py
@@ -32,6 +32,7 @@ INSTALLED_APPS = [
     'levels',
     'accountauth',
     'crispy_forms',
+    'crispy_bootstrap3',
     'projects',
     'django_otp',
     'django_otp.plugins.otp_totp',

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 django
 django-crispy-forms
+crispy-bootstrap3
 reportlab
 django_otp
 djangorestframework-jsonapi


### PR DESCRIPTION
 * With version 2.0 of django-crispy-forms the template packs are no longer part of the main package
 * This can be fixed by adding crispy-bootstrap3 to the requirements and referencing it in INSTALLED_APPS