### PR TITLE
fix(dockerfile): Make build succeed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,13 @@
 FROM alpine:latest
+ENV VIRTUAL_ENV=/opt/venv
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+
 RUN apk add --no-cache python3 && \
+    python3 -m venv $VIRTUAL_ENV && \
     python3 -m ensurepip && \
     pip3 install --upgrade pip setuptools && \
     if [ ! -e /usr/bin/pip ]; then ln -s pip3 /usr/bin/pip ; fi && \
-    if [[ ! -e /usr/bin/python ]]; then ln -sf /usr/bin/python3 /usr/bin/python; fi  
+    if [[ ! -e /usr/bin/python ]]; then ln -sf /usr/bin/python3 /usr/bin/python; fi
     
 COPY . /app
 WORKDIR /app


### PR DESCRIPTION
Create virtual environment in docker container to comply with PEP 668

I have tried to run a docker container of this repo but it kept exiting due to the following reason:

```
5.961 error: externally-managed-environment
5.961 
5.961 × This environment is externally managed
5.961 ╰─> 
5.961     The system-wide python installation should be maintained using the system
5.961     package manager (apk) only.
5.961     
5.961     If the package in question is not packaged already (and hence installable via
5.961     "apk add py3-somepackage"), please consider installing it inside a virtual
5.961     environment, e.g.:
5.961     
5.961     python3 -m venv /path/to/venv
5.961     . /path/to/venv/bin/activate
5.961     pip install mypackage
5.961     
5.961     To exit the virtual environment, run:
5.961     
5.961     deactivate
5.961     
5.961     The virtual environment is not deleted, and can be re-entered by re-sourcing
5.961     the activate file.
5.961     
5.961     To automatically manage virtual environments, consider using pipx (from the
5.961     pipx package).
5.961 
5.961 note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.
5.961 hint: See PEP 668 for the detailed specification.
```

I know that creating a virtual environment inside a container seems weird, and I saw that in the past, the base image has been changed to a version that was not affected by PEP 668. However, seems that more and more base images will adopt it, so it made sense to do this type of a fix, so the build process will be more stable. I have also explored the possibility of passing the `--break-system-packages`, but without success.

fixes #69 